### PR TITLE
Release 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ const PAYER = '5G7B3...';
 const AVN_AUTHORITY = '0xD3372...';
 
 async function main() {
+  // ******* OPTIONS *******
   const options = { suri: '0x816ef9f2c7f9e8c013fd5fca220a1bf23ff2f3b268f8bcd94d4b5df96534173f'};
   // For split fee functionality we can specify the payer in the options object.
   const splitFeeOptions = { suri: '0x816ef9f2c7f9e8c013fd5fca220a1bf23ff2f3b268f8bcd94d4b5df96534173f', payerAddress: PAYER };
@@ -43,6 +44,20 @@ async function main() {
   // Relayer defaults to Aventus if none is passed
   const relayerOptions = { suri: '0x816ef9f2c7f9e8c013fd5fca220a1bf23ff2f3b268f8bcd94d4b5df96534173f', relayer: '5FgyN...' };
 
+  // A remote signer and a user can be passed in instead of a suri. This function must be able to sign and return a signature
+  async function signData(encodedDataToSign, signerAccount) {
+    // Example:
+    //   Make an http call to a KMS to sign encodedData using signerAccount
+    //   and return the signature
+  }
+  const signerAccount = "5Gc8PokrcM6BsRPhJ63oHAiZhdm1L26wg7iekBE1FMbaUBde";
+
+  const remoteSignerOptions = {
+        sign: data => signData(data, signerAccount),
+        address: signerAccount
+  }
+
+  // ******* API SETUP *******
   const api = new AvnApi(AVN_GATEWAY_URL, options);
   const splitFeesApi = new AvnApi(AVN_GATEWAY_URL, splitFeeOptions);
   const defaultSplitFeesApi = new AvnApi(AVN_GATEWAY_URL, defaultSplitFeeOptions);

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ AvnApi.prototype.init = async function () {
 
   this.signer = () => (apiHasRemoteSigner(this.options) ? this.options.signer : Utils.getSigner(this.options.suri));
   this.myAddress = () => this.signer().address;
-  this.myPublicKey = () => Utils.convertToPublicKeyIfNeeded(this.myAddress());
+  this.myPublicKey = () => this.signer().publicKey;
 
   if (this.gateway) {
     this.awtToken = await Awt.generateAwtToken(this.options, this.signer());

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ AvnApi.prototype.init = async function () {
 
   this.signer = () => (apiHasRemoteSigner(this.options) ? this.options.signer : Utils.getSigner(this.options.suri));
   this.myAddress = () => this.signer().address;
-  this.myPublicKey = () => this.signer().publicKey;
+  this.myPublicKey = () => Utils.convertToHexIfNeeded(this.signer().publicKey);
 
   if (this.gateway) {
     this.awtToken = await Awt.generateAwtToken(this.options, this.signer());

--- a/index.js
+++ b/index.js
@@ -19,29 +19,54 @@ function AvnApi(gateway, options) {
 
 AvnApi.prototype.init = async function () {
   await cryptoWaitReady();
-  this.setSURI = suri => {
+  // TODO: do we want to allow changing SURI on the fly?
+  const setupSigner = () => {
+    this.options.suri = this.options.suri || process.env.AVN_SURI;
+
+    const hasRemoteSigner = apiHasRemoteSigner(this.options);
+    if (hasRemoteSigner === true) {
+      this.options.signer.publicKey = Utils.convertToPublicKeyBytes(this.options.signer.address);
+    }
+
+    if (!this.options.suri && !hasRemoteSigner) {
+      throw new Error('Invalid signer. Please pass a SURI, set AVN_SURI environment variable or specify a remote signer');
+    }
+  };
+
+  this.setSURI = async suri => {
+    if (!suri) throw new Error('Suri is a mandatory field');
     this.options.suri = suri;
-    this.awtToken = this.gateway ? Awt.generateAwtToken(this.options) : undefined;
+    this.options.signer = undefined;
+    this.awtToken = this.gateway ? await Awt.generateAwtToken(this.options, this.signer()) : undefined;
     console.info(' - Suri updated');
+  };
+
+  this.setSigner = async signer => {
+    if (!signer || !signer.address || typeof signer.sign !== 'function') {
+      throw new Error('Signer must be an object with a sign function and an address function');
+    }
+
+    this.options.suri = undefined;
+
+    signer.publicKey = Utils.convertToPublicKeyBytes(signer.address);
+
+    this.options.signer = signer;
+    this.awtToken = this.gateway ? await Awt.generateAwtToken(this.options, signer) : undefined;
+    console.info('\t - Signer updated');
   };
 
   this.awt = Awt;
   this.proxy = Proxy;
   this.utils = Utils;
 
-  // TODO: do we want to allow changing SURI on the fly?
-  const getSuri = () => {
-    this.options.suri = this.options.suri ?? process.env.AVN_SURI;
-    return this.options.suri;
-  };
+  setupSigner();
+
+  this.signer = () => (apiHasRemoteSigner(this.options) ? this.options.signer : Utils.getSigner(this.options.suri));
+  this.myAddress = () => this.signer().address;
+  this.myPublicKey = () => Utils.convertToPublicKeyIfNeeded(this.myAddress());
 
   if (this.gateway) {
-    if (!getSuri()) throw new Error('Suri is not defined');
-
-    this.signer = () => Utils.getSigner(getSuri());
-    this.myAddress = () => this.signer().address;
-    this.myPublicKey = () => Utils.convertToPublicKeyIfNeeded(this.myAddress());
-    this.awtToken = Awt.generateAwtToken(this.options);
+    this.awtToken = await Awt.generateAwtToken(this.options, this.signer());
 
     const avnApi = {
       relayer: () => this.relayer,
@@ -49,10 +74,10 @@ AvnApi.prototype.init = async function () {
       signer: () => this.signer(),
       hasSplitFeeToken: () => this.hasSplitFeeToken(),
       uuid: () => uuidv4(),
-      axios: () => {
+      axios: async () => {
         if (!Awt.tokenAgeIsValid(this.awtToken)) {
           console.log(' - Awt token has expired, refreshing');
-          this.awtToken = Awt.generateAwtToken(this.options);
+          this.awtToken = await Awt.generateAwtToken(this.options, this.signer());
         }
 
         // Add any middlewares here to configure global axios behaviours
@@ -64,7 +89,7 @@ AvnApi.prototype.init = async function () {
     this.query = new Query(avnApi);
     this.send = new Send(avnApi, this.query);
     this.poll = new Poll(avnApi);
-    this.relayer = common.validateAccount(this.options.relayer ?? (await this.query.getDefaultRelayer()));
+    this.relayer = common.validateAccount(this.options.relayer || (await this.query.getDefaultRelayer()));
   }
 };
 
@@ -74,5 +99,11 @@ AvnApi.prototype.hasSplitFeeToken = function () {
 
   return !!this.options.payerAddress;
 };
+
+function apiHasRemoteSigner(options) {
+  if (!options.signer) return false;
+
+  return !!options.signer.address && typeof options.signer.sign === 'function';
+}
 
 module.exports = AvnApi;

--- a/lib/awt.js
+++ b/lib/awt.js
@@ -7,9 +7,8 @@ const utils = require('./utils.js');
 const MAX_TOKEN_AGE_MSEC = 600000;
 const SIGNING_CONTEXT = 'awt_gateway_api';
 
-function generateAwtPayload(suri, issuedAt, options) {
-  const tokenOwner = common.keyring.addFromUri(suri);
-  const avnPublicKey = u8aToHex(tokenOwner.publicKey);
+async function generateAwtPayload(signer, issuedAt, options) {
+  const avnPublicKey = u8aToHex(signer.publicKey);
 
   let hasPayer = false;
   let payerAddress = undefined;
@@ -24,7 +23,7 @@ function generateAwtPayload(suri, issuedAt, options) {
   }
 
   const encodedData = encodeAvnPublicKeyForSigning(avnPublicKey, issuedAt, hasPayer, payerAddress);
-  const signature = tokenOwner.sign(encodedData);
+  const signature = await signer.sign(encodedData);
 
   return {
     pk: avnPublicKey,
@@ -35,12 +34,8 @@ function generateAwtPayload(suri, issuedAt, options) {
   };
 }
 
-function generateAwtToken(options) {
-  options = options || {};
-  options.suri = options.suri ?? process.env.AVN_SURI;
-  if (!options.suri) throw new Error('Please pass a SURI or set AVN_SURI environment variable');
-
-  let payload = generateAwtPayload(options.suri, new Date().toISOString(), options);
+async function generateAwtToken(options, signer) {
+  let payload = await generateAwtPayload(signer, new Date().toISOString(), options);
   return generateAwtTokenFromPayload(payload);
 }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -57,15 +57,19 @@ const RATE_STRUCTURE = ['parts_per_million'];
 function convertToPublicKeyIfNeeded(accountAddressOrPublicKey) {
   if (isAccountPK(accountAddressOrPublicKey)) {
     return accountAddressOrPublicKey;
-  } else {
-    try {
-      const pk = keyring.decodeAddress(accountAddressOrPublicKey);
-      return u8aToHex(pk);
-    } catch (error) {
-      const msg = 'Expected SS58 address (eg: "5FbUQ...") or hex public key (eg: "0x9c2bf..."), received:';
-      console.error('Error -', msg, accountAddressOrPublicKey, error);
-      return null;
-    }
+  }
+
+  const pk = convertToPublicKeyBytes(accountAddressOrPublicKey);
+  return u8aToHex(pk);
+}
+
+function convertToPublicKeyBytes(accountAddressOrPublicKey) {
+  try {
+    return keyring.decodeAddress(accountAddressOrPublicKey);
+  } catch (error) {
+    const msg = 'Expected SS58 address (eg: "5FbUQ...") or hex public key (eg: "0x9c2bf..."), received:';
+    console.error('Error -', msg, accountAddressOrPublicKey, error);
+    return null;
   }
 }
 
@@ -205,6 +209,7 @@ async function sleep(ms) {
 module.exports = {
   createTypeUnsafe,
   convertToPublicKeyIfNeeded,
+  convertToPublicKeyBytes,
   ETHEREUM_LOG_EVENT_TYPE,
   keyring,
   MARKET,

--- a/lib/poll.js
+++ b/lib/poll.js
@@ -20,7 +20,7 @@ function generateFunction(functionName, api) {
 
 Poll.prototype.postRequest = async function (api, method, params) {
   const endpoint = api.gateway + '/poll';
-  const response = await api.axios().post(endpoint, { jsonrpc: '2.0', id: api.uuid(), method: method, params: params });
+  const response = await (await api.axios()).post(endpoint, { jsonrpc: '2.0', id: api.uuid(), method: method, params: params });
   return response.data.result || response.data.error.message;
 };
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -223,7 +223,7 @@ function generateFunction(functionName, api) {
 
 Query.prototype.postRequest = async function (api, method, params, handler = 'query') {
   const endpoint = api.gateway + `/${handler}`;
-  const response = await api.axios().post(endpoint, { jsonrpc: '2.0', id: api.uuid(), method: method, params: params });
+  const response = await (await api.axios()).post(endpoint, { jsonrpc: '2.0', id: api.uuid(), method: method, params: params });
 
   if (!response || !response.data) {
     throw new Error('Invalid server response');
@@ -238,7 +238,7 @@ Query.prototype.postRequest = async function (api, method, params, handler = 'qu
 
 Query.prototype.getRequest = async function (api, method, params, handler = 'query') {
   const endpoint = api.gateway + `/${handler}?account=${params.account}`;
-  const response = await api.axios().get(endpoint);
+  const response = await (await api.axios()).get(endpoint);
 
   if (!response || !response.data) {
     throw new Error('Invalid server response');

--- a/lib/send.js
+++ b/lib/send.js
@@ -276,7 +276,7 @@ Send.prototype.postRequest = async function (api, method, params, retry) {
   }
 
   const endpoint = api.gateway + '/send';
-  const response = await api.axios().post(endpoint, { jsonrpc: '2.0', id: api.uuid(), method: method, params: params });
+  const response = await (await api.axios()).post(endpoint, { jsonrpc: '2.0', id: api.uuid(), method: method, params: params });
 
   if (!response || !response.data) {
     throw new Error('Invalid server response');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@
 
 const common = require('./common.js');
 const { mnemonicGenerate, mnemonicToMiniSecret } = require('@polkadot/util-crypto');
-const { u8aToHex } = require('@polkadot/util');
+const { u8aToHex, isHex } = require('@polkadot/util');
 
 function generateNewAccount() {
   const mnemonic = mnemonicGenerate();
@@ -26,6 +26,14 @@ function addressToPublicKeyBytes(address) {
   return common.convertToPublicKeyBytes(address);
 }
 
+function convertToHexIfNeeded(accountPublicKeyOrBytes) {
+  if (isHex(accountPublicKeyOrBytes)) {
+    return accountPublicKeyOrBytes;
+  }
+
+  return u8aToHex(accountPublicKeyOrBytes);
+}
+
 function getSigner(suri) {
   if (!suri) throw new Error('Unable to get signer because Suri is not defined');
   const user = common.keyring.addFromUri(suri);
@@ -41,6 +49,7 @@ module.exports = {
   addressToPublicKeyBytes,
   convertToPublicKeyIfNeeded: common.convertToPublicKeyIfNeeded,
   convertToPublicKeyBytes: common.convertToPublicKeyBytes,
+  convertToHexIfNeeded,
   generateNewAccount,
   getSigner
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,15 +21,26 @@ function addressToPublicKey(address) {
   return common.convertToPublicKeyIfNeeded(address);
 }
 
+function addressToPublicKeyBytes(address) {
+  common.validateAccount(address);
+  return common.convertToPublicKeyBytes(address);
+}
+
 function getSigner(suri) {
   if (!suri) throw new Error('Unable to get signer because Suri is not defined');
   const user = common.keyring.addFromUri(suri);
-  return user;
+  return {
+    sign: user.sign,
+    address: user.address,
+    publicKey: user.publicKey
+  };
 }
 
 module.exports = {
   addressToPublicKey,
+  addressToPublicKeyBytes,
   convertToPublicKeyIfNeeded: common.convertToPublicKeyIfNeeded,
+  convertToPublicKeyBytes: common.convertToPublicKeyBytes,
   generateNewAccount,
   getSigner
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avn-api",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "API wrapper around JSON-RPC calls to the AvN",
   "main": "index.js",
   "author": "Aventus Network Services",


### PR DESCRIPTION
**This is a breaking change release**

Introduces a `remote signer` capability to the api.

Users who do not want to expose a SURI can now pass in a remote signer function to the api. Every time the api needs to sign, it will invoke this function giving the user full control on how to sign and where to store the private keys. 
This will also facilitate third party wallet integration with the api.