### PR TITLE
Set `time to live` for lock and add retry

### DIFF
--- a/lib/apis/send.ts
+++ b/lib/apis/send.ts
@@ -264,6 +264,10 @@ export class Send {
     try {
       response = await axios.post(endpoint, { jsonrpc: '2.0', id: requestId, method: method, params: params });
     } catch (err) {
+        log.error("ERROR SENDING")
+        log.error(err, err.response, err.response?.status)
+        log.error(JSON.stringify(err))
+        log.error("ERROR SENDING")
       if (err.response?.status >= 500) {
         log.warn(
           new Date(),

--- a/lib/apis/send.ts
+++ b/lib/apis/send.ts
@@ -264,10 +264,6 @@ export class Send {
     try {
       response = await axios.post(endpoint, { jsonrpc: '2.0', id: requestId, method: method, params: params });
     } catch (err) {
-        log.error("ERROR SENDING")
-        log.error(err, err.response, err.response?.status)
-        log.error(JSON.stringify(err))
-        log.error("ERROR SENDING")
       if (err.response?.status >= 500) {
         log.warn(
           new Date(),

--- a/lib/caching/inMemoryLock.ts
+++ b/lib/caching/inMemoryLock.ts
@@ -1,6 +1,7 @@
 import log from 'loglevel';
+const MAX_LOCK_TIME_MS: number = 1000 * 60 * 5;
 export class InMemoryLock {
-  private locks: { [key: string]: { isLocked: boolean; requestQueue: (() => void)[] } };
+  private locks: { [key: string]: { isLocked: boolean; ttl: number; requestQueue: (() => void)[] } };
 
   constructor() {
     this.locks = {};
@@ -9,19 +10,23 @@ export class InMemoryLock {
   lock(key: string): Promise<void> {
     return new Promise(resolve => {
       if (!this.locks[key]) {
-        this.locks[key] = { isLocked: false, requestQueue: [] };
+        this.locks[key] = { isLocked: false, ttl: Number.MAX_SAFE_INTEGER, requestQueue: [] };
       }
 
       const request = () => {
         log.debug(new Date(), ` - Locking resource with key: ${key}.`);
         this.locks[key].isLocked = true;
+        this.locks[key].ttl = Date.now() + MAX_LOCK_TIME_MS;
         resolve();
       };
 
-      if (this.locks[key].isLocked) {
+      if (this.locks[key].isLocked && Date.now() < this.locks[key].ttl) {
         log.debug(new Date(), ` - Resource locked, ${key} added to lock Queue.`);
         this.locks[key].requestQueue.push(request);
       } else {
+        if (Date.now() < this.locks[key].ttl) {
+          log.debug(new Date(), ` - Resource max lock exceeded for key: ${key}. Unlocking`);
+        }
         request();
       }
     });
@@ -36,6 +41,7 @@ export class InMemoryLock {
     }
 
     lock.isLocked = false;
+    this.locks[key].ttl = Number.MAX_SAFE_INTEGER;
 
     const nextRequest = lock.requestQueue.shift();
     if (nextRequest) {


### PR DESCRIPTION
This PR sets a ttl for the resource lock logic and adds a retry if sending fails due to a network error.