### PR TITLE
fix param type

### DIFF
--- a/lib/apis/send.ts
+++ b/lib/apis/send.ts
@@ -270,7 +270,7 @@ export class Send {
     oracle: string,
     period: CreateMarketBaseParams['period'],
     deadlines: CreateMarketBaseParams['deadlines'],
-    metadata: string,
+    metadata: CreateMarketBaseParams['metaData'],
     amount: string,
     spotPrices: CreateMarketBaseParams['spotPrices']
   ): Promise<string> {

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -116,9 +116,9 @@ export type PredictionMarketConstants = {
   maxSwapFee: number;
 };
 
-export type PredictionMarketAsset = 
-  | { CategoricalOutcome: [string, string] }  
-  | { ForeignAsset: string };    
+export type PredictionMarketAsset =
+  | { CategoricalOutcome: [string, string] }
+  | { ForeignAsset: string };
 
 export enum Strategy {
   /// The trade is rolled back if it cannot be executed fully.
@@ -169,5 +169,8 @@ export type CreateMarketBaseParams = {
   };
   outcome: {
     Categorical: number;
+  };
+  metaData: {
+    Sha3_384: string;
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avn-api",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "API wrapper around JSON-RPC calls to the AvN",
   "main": "build/lib/index.js",
   "types": "build/lib/index.d.ts",


### PR DESCRIPTION
This PR fixes a bug where the type for `metaData` was incorrectly set as a string.