### PR TITLE
Refactor nonce management to handle non-user nonces

### DIFF
--- a/lib/apis/proxy.ts
+++ b/lib/apis/proxy.ts
@@ -638,7 +638,7 @@ async function signProxyRegisterNode({relayer, signerAddress, nodeId, nodeOwner,
     { AccountId: nodeIdPk },
     { AccountId: nodeOwnerPk },
     { AccountId: nodeSigningKey },
-    { blockNumber: blockNumber },
+    { BlockNumber: blockNumber },
   ];
 
   const encodedDataToSign = encodeOrderedData(orderedData);

--- a/lib/apis/proxy.ts
+++ b/lib/apis/proxy.ts
@@ -126,7 +126,8 @@ const signing = {
   proxyReportMarketOutcome: async proxyArgs => await signProxyReport(proxyArgs),
   proxyRedeemMarketShares: async proxyArgs => await signProxyRedeemShares(proxyArgs),
   proxyTransferMarketTokens: async proxyArgs => await signProxyTransferAsset(proxyArgs),
-  proxyWithdrawMarketTokens: async proxyArgs => await signProxyWithdrawMarketToken(proxyArgs)
+  proxyWithdrawMarketTokens: async proxyArgs => await signProxyWithdrawMarketToken(proxyArgs),
+  proxyRegisterNode: async proxyArgs => await signProxyRegisterNode(proxyArgs)
 };
 
 export default class ProxyUtils {
@@ -622,6 +623,24 @@ async function signProxyWithdrawMarketToken({ relayer, nonce, signerAddress, ass
     { AccountId: owner },
     { BalanceOf: amount }
   ];
+  const encodedDataToSign = encodeOrderedData(orderedData);
+  return await signData(api, signerAddress, encodedDataToSign);
+}
+
+async function signProxyRegisterNode({relayer, signerAddress, nodeId, nodeOwner, nodeSigningKey, blockNumber, api} ) {
+  const dataRelayer = AccountUtils.convertToPublicKeyIfNeeded(relayer);
+  const nodeIdPk = AccountUtils.convertToPublicKeyIfNeeded(nodeId);
+  const nodeOwnerPk = AccountUtils.convertToPublicKeyIfNeeded(nodeOwner);
+
+  const orderedData = [
+    { Text: 'register_node' },
+    { AccountId: dataRelayer },
+    { AccountId: nodeIdPk },
+    { AccountId: nodeOwnerPk },
+    { AccountId: nodeSigningKey },
+    { blockNumber: blockNumber },
+  ];
+
   const encodedDataToSign = encodeOrderedData(orderedData);
   return await signData(api, signerAddress, encodedDataToSign);
 }

--- a/lib/apis/query.ts
+++ b/lib/apis/query.ts
@@ -177,9 +177,7 @@ export class Query {
 
   async getUserNonce(accountAddress: string, nonceType: NonceType): Promise<string> {
     Utils.validateAccount(accountAddress);
-    console.log("Getting user nonce for account: " + accountAddress + " and nonce type: " + nonceType);
     const result = await this.postRequest<string>(this.api, 'getUserNonce', { accountId: accountAddress, nonceType });
-    console.log("User nonce result: " + result);
     return result;
   }
 

--- a/lib/apis/query.ts
+++ b/lib/apis/query.ts
@@ -177,8 +177,10 @@ export class Query {
 
   async getUserNonce(accountAddress: string, nonceType: NonceType): Promise<string> {
     Utils.validateAccount(accountAddress);
-
-    return await this.postRequest<string>(this.api, 'getUserNonce', { accountId: accountAddress, nonceType });
+    console.log("Getting user nonce for account: " + accountAddress + " and nonce type: " + nonceType);
+    const result = await this.postRequest<string>(this.api, 'getUserNonce', { accountId: accountAddress, nonceType });
+    console.log("User nonce result: " + result);
+    return result;
   }
 
   async getAnchorNonce(chainId: number): Promise<string> {

--- a/lib/apis/query.ts
+++ b/lib/apis/query.ts
@@ -175,10 +175,10 @@ export class Query {
     return await this.postRequest<string>(this.api, 'getTokenBalance', { accountId: accountAddress, token });
   }
 
-  async getNonce(accountAddress: string, nonceType: NonceType): Promise<string> {
+  async getUserNonce(accountAddress: string, nonceType: NonceType): Promise<string> {
     Utils.validateAccount(accountAddress);
 
-    return await this.postRequest<string>(this.api, 'getNonce', { accountId: accountAddress, nonceType });
+    return await this.postRequest<string>(this.api, 'getUserNonce', { accountId: accountAddress, nonceType });
   }
 
   async getAnchorNonce(chainId: number): Promise<string> {
@@ -352,7 +352,7 @@ export class Query {
     return await this.postRequest<string>(this.api, 'getEthereumEventStatus', { txHash });
   }
 
-  async getCheckpointByOriginId(chainId: string, originId:string): Promise<string> {
-    return await this.postRequest<string>(this.api, 'getCheckpointByOriginId', {chainId, originId})
+  async getCheckpointByOriginId(chainId: string, originId: string): Promise<string> {
+    return await this.postRequest<string>(this.api, 'getCheckpointByOriginId', { chainId, originId });
   }
 }

--- a/lib/apis/send.ts
+++ b/lib/apis/send.ts
@@ -51,7 +51,7 @@ export class Send {
     this.signerAddress = signerAddress;
     this.nonceGuard = nonceGuard;
     this.feesMap = {};
-    this.paymentNonceId = Utils.getNonceId({ nonceType: NonceType.Payment, nonceParams: { user: this.signerAddress } });
+    this.paymentNonceId = NonceUtils.getNonceId({ nonceType: NonceType.Payment, nonceParams: { user: this.signerAddress } });
   }
 
   async transferAvt(recipient: string, amount: string): Promise<string> {
@@ -442,10 +442,10 @@ export class Send {
   async proxyRequest(methodArgs: any, transactionType: TxType, nonceInfo: NonceInfo): Promise<string> {
     let proxyNonceData: NonceData, paymentNonceData: NonceData, proxyNonce: number, paymentNonce: number | undefined;
     const requestId = this.api.uuid();
-    const nonceId = Utils.getNonceId(nonceInfo);
+    const nonceId = NonceUtils.getNonceId(nonceInfo);
 
     // Lock while we are sending the transaction to ensure we maintain a correct order
-    const lockKey = `send-${this.signerAddress}-${Utils.createLockKeyFromNonceInfo(nonceInfo)}`;
+    const lockKey = `send-${this.signerAddress}-${NonceUtils.createLockKeyFromNonceInfo(nonceInfo)}`;
     await this.nonceGuard.lock(lockKey);
 
     log.info(``);
@@ -460,7 +460,7 @@ export class Send {
         proxyNonce = await this.api.nonceCache.incrementNonce(
           proxyNonceData,
           this.signerAddress,
-          Utils.getNonceId(nonceInfo),
+          NonceUtils.getNonceId(nonceInfo),
           requestId,
           NonceUtils.createNonceFetcher(nonceInfo, this.queryApi)
         );
@@ -574,7 +574,7 @@ export class Send {
       return await this.api.nonceCache.incrementNonce(
         proxyNonceData,
         this.signerAddress,
-        Utils.getNonceId(nonceInfo),
+        NonceUtils.getNonceId(nonceInfo),
         requestId,
         fnRefreshNonce
       );

--- a/lib/apis/send.ts
+++ b/lib/apis/send.ts
@@ -430,12 +430,14 @@ export class Send {
     Utils.validateAccount(nodeOwner);
     Utils.validateAccount(nodeSigningKey);
 
+    const blockNumber = await this.queryApi.getCurrentBlock();
     const methodArgs = {
       nodeId,
       nodeOwner,
-      nodeSigningKey
+      nodeSigningKey,
+      blockNumber
     };
-    const nonceInfo = { nonceType: NonceType.NodeManager, nonceParams: { user: this.signerAddress }};
+    const nonceInfo = { nonceType: NonceType.None, nonceParams: {}};
     return await this.proxyRequest(methodArgs, TxType.ProxyRegisterNode, nonceInfo);
   }
 

--- a/lib/apis/send.ts
+++ b/lib/apis/send.ts
@@ -430,6 +430,7 @@ export class Send {
     Utils.validateAccount(nodeOwner);
     Utils.validateAccount(nodeSigningKey);
 
+    nodeSigningKey = AccountUtils.convertToPublicKeyIfNeeded(nodeSigningKey);
     const blockNumber = await this.queryApi.getCurrentBlock();
     const methodArgs = {
       nodeId,

--- a/lib/apis/send.ts
+++ b/lib/apis/send.ts
@@ -461,7 +461,6 @@ export class Send {
           proxyNonceData,
           this.signerAddress,
           Utils.getNonceId(nonceInfo),
-          this.queryApi,
           requestId,
           NonceUtils.createNonceFetcher(nonceInfo, this.queryApi)
         );
@@ -576,7 +575,6 @@ export class Send {
         proxyNonceData,
         this.signerAddress,
         Utils.getNonceId(nonceInfo),
-        this.queryApi,
         requestId,
         fnRefreshNonce
       );
@@ -607,7 +605,6 @@ export class Send {
           paymentNonceData,
           this.signerAddress,
           this.paymentNonceId,
-          this.queryApi,
           requestId,
           NonceUtils.createNonceFetcher(
             { nonceType: NonceType.Payment, nonceParams: { user: this.signerAddress } },

--- a/lib/avnApi.ts
+++ b/lib/avnApi.ts
@@ -4,7 +4,7 @@ import { cryptoWaitReady, isEthereumAddress } from '@polkadot/util-crypto';
 import { Query, Send, Poll } from './apis';
 import { NonceCache, InMemoryNonceCacheProvider, NonceData } from './caching';
 import { Awt, AwtUtils } from './awt';
-import { AccountUtils, Utils } from './utils';
+import { AccountUtils, NonceUtils, Utils } from './utils';
 import { version } from '../package.json';
 import { AvnApiConfig, AvnApiOptions, SigningMode, SetupMode, Signer, NonceType } from './interfaces';
 import { NonceCacheType, InMemoryLock } from './caching';
@@ -31,6 +31,7 @@ export class AvnApi {
   public gateway: string;
   public relayer: string;
   public accountUtils: AccountUtils;
+  public nonceUtils: NonceUtils;
   public awtUtils: AwtUtils;
   public proxyUtils: ProxyUtils;
   public apis: (signerAddress: string) => Promise<Apis>;
@@ -50,6 +51,7 @@ export class AvnApi {
     this.version = version;
     this.gateway = gateway;
     this.accountUtils = AccountUtils;
+    this.nonceUtils = NonceUtils;
 
     if (this.options.signingMode === SigningMode.SuriBased) {
       this.#suri = options.suri || process?.env?.AVN_SURI;

--- a/lib/avnApi.ts
+++ b/lib/avnApi.ts
@@ -16,7 +16,7 @@ interface Apis {
   query: Query;
   send: Send;
   poll: Poll;
-  proxyNonce: (signerAddress: string, nonceType: NonceType) => Promise<NonceData | undefined>;
+  proxyNonce: (signerAddress: string, nonceId: string) => Promise<NonceData | undefined>;
 }
 
 export type { Apis };
@@ -153,8 +153,7 @@ export class AvnApi {
       query: query,
       send: new Send(avnApi, query, awt, nonceGuard, signerAddress),
       poll: new Poll(avnApi, awt),
-      proxyNonce: async (signerAddress: string, nonceType: NonceType) =>
-        await avnApi.nonceCache.getNonceData(signerAddress, nonceType)
+      proxyNonce: async (signerAddress: string, nonceId: string) => await avnApi.nonceCache.getNonceData(signerAddress, nonceId)
     };
   }
 

--- a/lib/caching/NonceCache.ts
+++ b/lib/caching/NonceCache.ts
@@ -9,7 +9,7 @@ const TX_PROCESSING_TIME_MS = 120000;
 const NONCE_LOCK_POLL_INTERVAL_MS = 500;
 const MAX_NONCE_LOCK_TIME_MS = TX_PROCESSING_TIME_MS + NONCE_LOCK_POLL_INTERVAL_MS;
 const EXPIRY_UPDATE_ENUM = {
-  DoNotUpade: false,
+  DoNotUpdate: false,
   UpdateExpiry: true
 };
 
@@ -139,7 +139,7 @@ export class NonceCache {
         ` ${requestId} - Nonce expired but on-chain nonce ${nonceFromChain} is the same as last nonce used ${nonceData.nonce}.`
       );
       const incrementedNonce = (
-        await this.cacheProvider.incrementNonce(lockId, signerAddress, nonceId, EXPIRY_UPDATE_ENUM.DoNotUpade)
+        await this.cacheProvider.incrementNonce(lockId, signerAddress, nonceId, EXPIRY_UPDATE_ENUM.DoNotUpdate)
       ).nonce;
 
       await Utils.sleep(TX_PROCESSING_TIME_MS);

--- a/lib/caching/NonceCache.ts
+++ b/lib/caching/NonceCache.ts
@@ -57,7 +57,6 @@ export class NonceCache {
     nonceData: NonceData,
     signerAddress: string,
     nonceId: string,
-    queryApi: Query,
     requestId: string,
     fnRefreshNonce: () => Promise<string>
   ): Promise<number> {
@@ -67,7 +66,7 @@ export class NonceCache {
 
       if (nonceIsExpired) {
         log.debug(new Date(), ` ${requestId} - Nonce expired. Nonce data: ${JSON.stringify(nonceData)}.`);
-        return await this.refreshNonceFromChain(nonceData.lockId, signerAddress, nonceId, nonceData, queryApi, requestId, fnRefreshNonce);
+        return await this.refreshNonceFromChain(nonceData.lockId, signerAddress, nonceId, nonceData, requestId, fnRefreshNonce);
       }
 
       return (
@@ -124,7 +123,6 @@ export class NonceCache {
     signerAddress: string,
     nonceId: string,
     nonceData: NonceData,
-    queryApi: Query,
     requestId: string,
     fnRefreshNonce: () => Promise<string>
   ): Promise<number> {

--- a/lib/caching/inMemoryNonceCacheProvider.ts
+++ b/lib/caching/inMemoryNonceCacheProvider.ts
@@ -62,6 +62,7 @@ export class InMemoryNonceCacheProvider implements INonceCacheProvider {
       nonceData.lastUpdated = Date.now();
     }
 
+    this.nonceMap[signerAddress][nonceId] = nonceData;
     return nonceData;
   }
 
@@ -77,6 +78,7 @@ export class InMemoryNonceCacheProvider implements INonceCacheProvider {
 
     nonceData.locked = false;
     nonceData.lockId = undefined;
+    this.nonceMap[signerAddress][nonceId] = nonceData;
   }
 
   async setNonce(lockId: string, signerAddress: string, nonceId: string, nonce: number): Promise<void> {
@@ -87,6 +89,7 @@ export class InMemoryNonceCacheProvider implements INonceCacheProvider {
 
     nonceData.nonce = nonce;
     nonceData.lastUpdated = Date.now();
+    this.nonceMap[signerAddress][nonceId] = nonceData;
   }
 
   private getLockId(signerAddress: string, nonceId: string, nonce: number): string {

--- a/lib/caching/inMemoryNonceCacheProvider.ts
+++ b/lib/caching/inMemoryNonceCacheProvider.ts
@@ -43,6 +43,7 @@ export class InMemoryNonceCacheProvider implements INonceCacheProvider {
       const lockId = this.getLockId(signerAddress, nonceId, nonceData.nonce);
       nonceData.locked = true;
       nonceData.lockId = lockId;
+      this.nonceMap[signerAddress][nonceId] = nonceData;
       return { lockAquired: true, data: nonceData };
     } finally {
       this.nonceGuard.unlock(lockKey);

--- a/lib/caching/inMemoryNonceCacheProvider.ts
+++ b/lib/caching/inMemoryNonceCacheProvider.ts
@@ -16,53 +16,44 @@ export class InMemoryNonceCacheProvider implements INonceCacheProvider {
 
   async initUserNonceCache(signerAddress: string): Promise<void> {
     if (this.nonceMap[signerAddress] === undefined) {
-      this.nonceMap[signerAddress] = Object.values(NonceType).reduce(
-        (o, key) => ({
-          ...o,
-          [key]: {
-            locked: false
-          }
-        }),
-        {}
-      );
+      this.nonceMap[signerAddress] = {};
     }
   }
 
   // Note: this is a "dirty" read from storage
-  async getNonceData(signerAddress: string, nonceType: NonceType): Promise<NonceData | undefined> {
+  async getNonceData(signerAddress: string, nonceId: string): Promise<NonceData> {
     const userCache = this.nonceMap[signerAddress];
-    return userCache ? userCache[nonceType] : undefined;
+    if (userCache && userCache[nonceId]) {
+      return userCache[nonceId];
+    }
+
+    return { nonce: 0, locked: false, lockId: undefined, lastUpdated: 0 };
   }
 
-  async getNonceAndLock(signerAddress: string, nonceType: NonceType): Promise<CachedNonceInfo> {
-    const lockKey = `memNonceCache-${signerAddress}${nonceType}`;
+  async getNonceAndLock(signerAddress: string, nonceId: string): Promise<CachedNonceInfo> {
+    const lockKey = `memNonceCache-${signerAddress}${nonceId}`;
     await this.nonceGuard.lock(lockKey);
 
     try {
-      const nonceData = this.nonceMap[signerAddress][nonceType];
-      if (nonceData.locked === false) {
-        const lockId = this.getLockId(signerAddress, nonceType, nonceData.nonce);
-        nonceData.locked = true;
-        nonceData.lockId = lockId;
-        return { lockAquired: true, data: nonceData };
+      const nonceData = await this.getNonceData(signerAddress, nonceId);
+      if (nonceData.locked === true) {
+        return { lockAquired: false, data: nonceData };
       }
 
-      return { lockAquired: false, data: nonceData };
+      const lockId = this.getLockId(signerAddress, nonceId, nonceData.nonce);
+      nonceData.locked = true;
+      nonceData.lockId = lockId;
+      return { lockAquired: true, data: nonceData };
     } finally {
       this.nonceGuard.unlock(lockKey);
     }
   }
 
-  async incrementNonce(
-    lockId: string,
-    signerAddress: string,
-    nonceType: NonceType,
-    updateLastUpdate: boolean
-  ): Promise<NonceData> {
-    const nonceData = this.nonceMap[signerAddress][nonceType];
-    if (nonceData.locked === false || nonceData.lockId !== lockId) {
+  async incrementNonce(lockId: string, signerAddress: string, nonceId: string, updateLastUpdate: boolean): Promise<NonceData> {
+    const nonceData = await this.getNonceData(signerAddress, nonceId);
+    if (nonceData.locked !== true || nonceData.lockId !== lockId) {
       throw new Error(
-        `Invalid attempt to increment lock. LockId: ${lockId}, signerAddress: ${signerAddress}, nonceType: ${nonceType}`
+        `Invalid attempt to increment lock. LockId: ${lockId}, signerAddress: ${signerAddress}, nonceId: ${nonceId}`
       );
     }
 
@@ -74,13 +65,13 @@ export class InMemoryNonceCacheProvider implements INonceCacheProvider {
     return nonceData;
   }
 
-  async unlockNonce(lockId: string, signerAddress: string, nonceType: NonceType): Promise<void> {
-    const nonceData = this.nonceMap[signerAddress][nonceType];
-    if (nonceData.locked === false || nonceData.lockId !== lockId) {
+  async unlockNonce(lockId: string, signerAddress: string, nonceId: string): Promise<void> {
+    const nonceData = await this.getNonceData(signerAddress, nonceId);
+    if (nonceData.locked !== true || nonceData.lockId !== lockId) {
       throw new Error(
         `Invalid attempt to unlock nonce. Current nonce data: ${JSON.stringify(
           nonceData
-        )}. LockId: ${lockId}, signerAddress: ${signerAddress}, nonceType: ${nonceType}`
+        )}. LockId: ${lockId}, signerAddress: ${signerAddress}, nonceId: ${nonceId}`
       );
     }
 
@@ -88,19 +79,17 @@ export class InMemoryNonceCacheProvider implements INonceCacheProvider {
     nonceData.lockId = undefined;
   }
 
-  async setNonce(lockId: string, signerAddress: string, nonceType: NonceType, nonce: number): Promise<void> {
-    const nonceData = this.nonceMap[signerAddress][nonceType];
-    if (nonceData.locked === false || nonceData.lockId !== lockId) {
-      throw new Error(
-        `Invalid attempt to set nonce. LockId: ${lockId}, signerAddress: ${signerAddress}, nonceType: ${nonceType}`
-      );
+  async setNonce(lockId: string, signerAddress: string, nonceId: string, nonce: number): Promise<void> {
+    const nonceData = await this.getNonceData(signerAddress, nonceId);
+    if (nonceData.locked !== true || nonceData.lockId !== lockId) {
+      throw new Error(`Invalid attempt to set nonce. LockId: ${lockId}, signerAddress: ${signerAddress}, nonceId: ${nonceId}`);
     }
 
     nonceData.nonce = nonce;
     nonceData.lastUpdated = Date.now();
   }
 
-  private getLockId(signerAddress: string, nonceType: NonceType, nonce: number): string {
-    return `${Date.now()}-${nonce}-${signerAddress}-${nonceType}`;
+  private getLockId(signerAddress: string, nonceId: string, nonce: number): string {
+    return `${Date.now()}-${nonce}-${signerAddress}-${nonceId}`;
   }
 }

--- a/lib/caching/interfaces.ts
+++ b/lib/caching/interfaces.ts
@@ -21,13 +21,13 @@ export interface INonceCacheProvider {
   // Setup a new cache object for the user. This will only be called once per user during the initialisation of the 'apis()'
   initUserNonceCache(signerAddress: string): Promise<void>;
   // Lock the nonce and return the nonce info
-  getNonceAndLock(signerAddress: string, nonceType: string): Promise<CachedNonceInfo>;
+  getNonceAndLock(signerAddress: string, nonceId: string): Promise<CachedNonceInfo>;
   // Read the current nonce data.
-  getNonceData(signerAddress: string, nonceType: string): Promise<NonceData>;
+  getNonceData(signerAddress: string, nonceId: string): Promise<NonceData>;
   // Increment nonce by 1. Should only succeed if lockId matches the active lock.
-  incrementNonce(lockId: string, signerAddress: string, nonceType: string, updateLastUpdate: boolean): Promise<NonceData>;
+  incrementNonce(lockId: string, signerAddress: string, nonceId: string, updateLastUpdate: boolean): Promise<NonceData>;
   // Unlock nonce. Should only succeed if lockId matches the active lock.
-  unlockNonce(lockId: string, signerAddress: string, nonceType: string): Promise<void>;
+  unlockNonce(lockId: string, signerAddress: string, nonceId: string): Promise<void>;
   // Reset nonce to a different value. Should only succeed if lockId matches the active lock.
-  setNonce(lockId: string, signerAddress: string, nonceType: string, nonce: number): Promise<void>;
+  setNonce(lockId: string, signerAddress: string, nonceId: string, nonce: number): Promise<void>;
 }

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -17,7 +17,6 @@ export enum NonceType {
   Prediction_Market = 'prediction_Market',
   Prediction_User = 'prediction_User',
   HybridRouter = 'hybridRouter',
-  NodeManager = 'nodeManager',
   None = 'none'
 }
 

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -14,8 +14,8 @@ export enum NonceType {
   Nft = 'nft',
   Batch = 'batch',
   Anchor = 'anchor',
-  Prediction_Market = 'predictionMarket',
-  Prediction_User = 'predictionUser',
+  Prediction_Market = 'prediction_Market',
+  Prediction_User = 'prediction_User',
   HybridRouter = 'hybridRouter',
   NodeManager = 'nodeManager',
   None = 'none'

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -4,6 +4,8 @@ import { Query } from '../apis/query';
 import { LogLevelNames } from 'loglevel';
 import { AxiosStatic } from 'axios';
 
+// NOTE: Nonce types should not be per pallet, instead they should be based
+// on the nonce storage item and parameters. Ex: Prediction has 2 nonces: (User based and Market based)
 export enum NonceType {
   Token = 'token',
   Payment = 'payment',
@@ -12,9 +14,16 @@ export enum NonceType {
   Nft = 'nft',
   Batch = 'batch',
   Anchor = 'anchor',
-  PredictionMarkets = 'predictionMarkets',
+  Prediction_Market = 'predictionMarket',
+  Prediction_User = 'predictionUser',
   HybridRouter = 'hybridRouter',
+  NodeManager = 'nodeManager',
   None = 'none'
+}
+
+export interface NonceInfo {
+  nonceType: NonceType;
+  nonceParams: {};
 }
 
 export enum SetupMode {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -3,6 +3,7 @@ import { Keyring } from '@polkadot/keyring';
 
 export * from './accountUtils';
 export * from './utils';
+export * from './nonceUtils';
 
 export const registry = new TypeRegistry();
 export const keyring = new Keyring({ type: 'sr25519', ss58Format: 42 });
@@ -38,14 +39,17 @@ export enum TxType {
   ProxyRegisterHander = 'proxyRegisterHandler',
   ProxySubmitCheckpoint = 'proxySubmitCheckpoint',
 
-  // Prediction market
+  // Prediction_Market market
   ProxyCreateMarketAndDeployPool = 'proxyCreateMarketAndDeployPool',
   ProxyReportMarketOutcome = 'proxyReportMarketOutcome',
   ProxyRedeemMarketShares = 'proxyRedeemMarketShares',
   ProxyTransferMarketTokens = 'proxyTransferMarketTokens',
   ProxyBuyMarketOutcomeTokens = 'proxyBuyMarketOutcomeTokens',
   ProxySellMarketOutcomeTokens = 'proxySellMarketOutcomeTokens',
-  ProxyWithdrawMarketTokens = 'proxyWithdrawMarketTokens'
+  ProxyWithdrawMarketTokens = 'proxyWithdrawMarketTokens',
+
+  // Node manager
+  ProxyRegisterNode = 'proxyRegisterNode'
 }
 
 export enum EthereumLogEventType {

--- a/lib/utils/nonceUtils.ts
+++ b/lib/utils/nonceUtils.ts
@@ -42,7 +42,6 @@ export class NonceUtils {
       case NonceType.Staking:
       case NonceType.Batch:
       case NonceType.Confirmation:
-      case NonceType.NodeManager:
       case NonceType.Prediction_User: {
         if (!nonceParams['user']) throw new Error(`user is required for NonceType ${nonceType}`);
         return () => queryApi.getUserNonce(nonceParams['user'], nonceType);

--- a/lib/utils/nonceUtils.ts
+++ b/lib/utils/nonceUtils.ts
@@ -26,13 +26,13 @@ export class NonceUtils {
         return () => queryApi.getAnchorNonce(nonceParams['chainId']);
       }
       case NonceType.Prediction_Market: {
-        if (!nonceParams['marketId'] || !nonceParams['user']) {
+        if (!nonceParams['marketId'] == null || !nonceParams['user']) {
           throw new Error('marketId and user are required for NonceType.Prediction_Market');
         }
         return () => queryApi.getPredictionMarketsNonce(nonceParams['marketId'], nonceParams['user']);
       }
       case NonceType.HybridRouter: {
-        if (!nonceParams['marketId'] || !nonceParams['user']) {
+        if (!nonceParams['marketId'] == null || !nonceParams['user']) {
           throw new Error('marketId and user are required for NonceType.HybridRouter');
         }
         return () => queryApi.getHybridRouterNonce(nonceParams['marketId'], nonceParams['user']);

--- a/lib/utils/nonceUtils.ts
+++ b/lib/utils/nonceUtils.ts
@@ -2,6 +2,7 @@
 
 import { NonceInfo, NonceType } from '../interfaces';
 import { Query } from '../apis';
+import { createHash } from 'crypto';
 
 export class NonceUtils {
   /**
@@ -54,5 +55,17 @@ export class NonceUtils {
         throw new Error(`Invalid nonce type: ${nonceType}`);
       }
     }
+  }
+
+  static createLockKeyFromNonceInfo(nonceInfo: NonceInfo): string {
+    const sortedParams: any = {};
+    for (const key of Object.keys(nonceInfo.nonceParams).sort()) {
+      sortedParams[key] = nonceInfo.nonceParams[key];
+    }
+    return `${nonceInfo.nonceType}-${createHash('sha256').update(JSON.stringify(sortedParams)).digest('hex')}`;
+  }
+
+  static getNonceId(nonceInfo: NonceInfo): string {
+    return this.createLockKeyFromNonceInfo(nonceInfo);
   }
 }

--- a/lib/utils/nonceUtils.ts
+++ b/lib/utils/nonceUtils.ts
@@ -1,0 +1,58 @@
+'use strict';
+
+import { NonceInfo, NonceType } from '../interfaces';
+import { Query } from '../apis';
+
+export class NonceUtils {
+  /**
+   * Creates and returns a function that fetches a nonce based on the provided nonce information.
+   * @param nonceInfo - Information about the nonce type and parameters.
+   * @param queryApi - The API instance to use for fetching the nonce.
+   * @returns A function that, when called, returns a promise resolving to the nonce string.
+   */
+  static createNonceFetcher(nonceInfo: NonceInfo, queryApi: Query): () => Promise<string> {
+    if (!nonceInfo) throw new Error('Nonce info is required');
+
+    const { nonceType, nonceParams } = nonceInfo;
+
+    switch (nonceType) {
+      case NonceType.Nft: {
+        if (!nonceParams['nftId']) throw new Error('nftId is required for NonceType.Nft');
+        return () => queryApi.getNftNonce(nonceParams['nftId']);
+      }
+      case NonceType.Anchor: {
+        if (!nonceParams['chainId']) throw new Error('chainId is required for NonceType.Anchor');
+        return () => queryApi.getAnchorNonce(nonceParams['chainId']);
+      }
+      case NonceType.Prediction_Market: {
+        if (!nonceParams['marketId'] || !nonceParams['user']) {
+          throw new Error('marketId and user are required for NonceType.Prediction_Market');
+        }
+        return () => queryApi.getPredictionMarketsNonce(nonceParams['marketId'], nonceParams['user']);
+      }
+      case NonceType.HybridRouter: {
+        if (!nonceParams['marketId'] || !nonceParams['user']) {
+          throw new Error('marketId and user are required for NonceType.HybridRouter');
+        }
+        return () => queryApi.getHybridRouterNonce(nonceParams['marketId'], nonceParams['user']);
+      }
+      case NonceType.Token:
+      case NonceType.Payment:
+      case NonceType.Staking:
+      case NonceType.Batch:
+      case NonceType.Confirmation:
+      case NonceType.NodeManager:
+      case NonceType.Prediction_User: {
+        if (!nonceParams['user']) throw new Error(`user is required for NonceType ${nonceType}`);
+        return () => queryApi.getUserNonce(nonceParams['user'], nonceType);
+      }
+      // TODO: Confirm if returning "0" is the desired behavior for NonceType.None
+      case NonceType.None: {
+        return () => Promise.resolve('0');
+      }
+      default: {
+        throw new Error(`Invalid nonce type: ${nonceType}`);
+      }
+    }
+  }
+}

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -7,7 +7,6 @@ import BN from 'bn.js';
 import { NonceInfo, Royalty, Signer } from '../interfaces';
 import { Query } from '../apis/query';
 import { keyring } from './index';
-import { createHash } from 'crypto';
 
 export class Utils {
   static validateAccount(account: string) {
@@ -158,17 +157,5 @@ export class Utils {
     if (name.length > CHAIN_NAME_LIMIT) {
       throw new Error(`Chain name exceeds the limit of ${CHAIN_NAME_LIMIT} bytes`);
     }
-  }
-
-  static createLockKeyFromNonceInfo(nonceInfo: NonceInfo): string {
-    const sortedParams: any = {};
-    for (const key of Object.keys(nonceInfo.nonceParams).sort()) {
-      sortedParams[key] = nonceInfo.nonceParams[key];
-    }
-    return `${nonceInfo.nonceType}-${createHash('sha256').update(JSON.stringify(sortedParams)).digest('hex')}`;
-  }
-
-  static getNonceId(nonceInfo: NonceInfo): string {
-    return this.createLockKeyFromNonceInfo(nonceInfo);
   }
 }

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -4,9 +4,10 @@ import { hexToU8a, isHex, u8aToHex, isNumber } from '@polkadot/util';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 import { validate as uuidValidate } from 'uuid';
 import BN from 'bn.js';
-import { Royalty, Signer } from '../interfaces';
+import { NonceInfo, Royalty, Signer } from '../interfaces';
 import { Query } from '../apis/query';
 import { keyring } from './index';
+import { createHash } from 'crypto';
 
 export class Utils {
   static validateAccount(account: string) {
@@ -157,5 +158,17 @@ export class Utils {
     if (name.length > CHAIN_NAME_LIMIT) {
       throw new Error(`Chain name exceeds the limit of ${CHAIN_NAME_LIMIT} bytes`);
     }
+  }
+
+  static createLockKeyFromNonceInfo(nonceInfo: NonceInfo): string {
+    const sortedParams: any = {};
+    for (const key of Object.keys(nonceInfo.nonceParams).sort()) {
+      sortedParams[key] = nonceInfo.nonceParams[key];
+    }
+    return `${nonceInfo.nonceType}-${createHash('sha256').update(JSON.stringify(sortedParams)).digest('hex')}`;
+  }
+
+  static getNonceId(nonceInfo: NonceInfo): string {
+    return this.createLockKeyFromNonceInfo(nonceInfo);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avn-api",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "API wrapper around JSON-RPC calls to the AvN",
   "main": "build/lib/index.js",
   "types": "build/lib/index.d.ts",


### PR DESCRIPTION
This pull request includes several updates to the `Query` and `Send` classes in the `lib/apis` directory, with a focus on improving nonce handling and logging. The most important changes include refactoring nonce management to handle non user nonces in remote cache mode (Example PredictionMarket or Anchor nonce). 

### Improvements to `Query` class:
* Renamed `getNonce` method to `getUserNonce` and added logging statements to track the process of fetching the nonce.
* Introduce new nonce types based on the argument to fetch the nonce
### Improvements to `Send` class:
* Added a new private member `paymentNonceId` and initialized it in the constructor. [[1]](diffhunk://#diff-59c09728d34b4d2d9acdd0319de4653704987c0a63d2d78c9588c8bf8e9e84b7L38-R45) [[2]](diffhunk://#diff-59c09728d34b4d2d9acdd0319de4653704987c0a63d2d78c9588c8bf8e9e84b7R54-R217)
* Updated multiple methods to use the `NonceInfo` interface for nonce handling, replacing the previous `NonceType` usage. [[1]](diffhunk://#diff-59c09728d34b4d2d9acdd0319de4653704987c0a63d2d78c9588c8bf8e9e84b7R54-R217) [[2]](diffhunk://#diff-59c09728d34b4d2d9acdd0319de4653704987c0a63d2d78c9588c8bf8e9e84b7L223-R272) [[3]](diffhunk://#diff-59c09728d34b4d2d9acdd0319de4653704987c0a63d2d78c9588c8bf8e9e84b7L325-R334) [[4]](diffhunk://#diff-59c09728d34b4d2d9acdd0319de4653704987c0a63d2d78c9588c8bf8e9e84b7L336-R354) [[5]](diffhunk://#diff-59c09728d34b4d2d9acdd0319de4653704987c0a63d2d78c9588c8bf8e9e84b7L368-R380) [[6]](diffhunk://#diff-59c09728d34b4d2d9acdd0319de4653704987c0a63d2d78c9588c8bf8e9e84b7L393-R406) [[7]](diffhunk://#diff-59c09728d34b4d2d9acdd0319de4653704987c0a63d2d78c9588c8bf8e9e84b7L402-L443)
* Added a new method `registerNode` to handle node registration with nonce management.
* Modified the `proxyRequest` method to accept `NonceInfo` and updated nonce locking and incrementing logic.