### PR TITLE
Add nonceUtils test

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "prepare": "npm run build",
     "pretty": "prettier --config ./.prettierrc.json --check \"**/*.{ts,json}\"",
     "pretty:fix": "prettier --config ./.prettierrc.json --write \"**/*.{ts,json}\"",
-    "lint": "eslint . --ext .ts"
+    "lint": "eslint . --ext .ts",
+    "test": "ts-node ./test/nonceUtils.test.ts"
   }
 }

--- a/test/nonceUtils.test.ts
+++ b/test/nonceUtils.test.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import { NonceUtils } from '../lib/utils/nonceUtils';
+import { NonceType } from '../lib/interfaces';
+
+// Mock Query object with only getAnchorNonce implemented
+const mockQuery = {
+  getAnchorNonce: async (chainId: string): Promise<string> => `anchor-${chainId}`
+} as any;
+
+(async () => {
+  // Expect error when chainId is missing
+  let threw = false;
+  try {
+    NonceUtils.createNonceFetcher({ nonceType: NonceType.Anchor, nonceParams: {} }, mockQuery);
+  } catch (err) {
+    threw = true;
+  }
+  assert.ok(threw, 'Expected error when chainId is missing');
+
+  // Expect returned function to call getAnchorNonce with provided chainId
+  const fetcher = NonceUtils.createNonceFetcher(
+    { nonceType: NonceType.Anchor, nonceParams: { chainId: '5' } },
+    mockQuery
+  );
+  const value = await fetcher();
+  assert.strictEqual(value, 'anchor-5');
+
+  console.log('All tests passed');
+})();
+


### PR DESCRIPTION
## Summary
- add a unit test for `createNonceFetcher`
- support running tests with ts-node

## Testing
- `npm test` *(fails: ts-node not found)*